### PR TITLE
오타 및 맞춤법 교정 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from datetime import datetime #재우님
 from konlpy.tag import Okt #종명
 import time
 import requests
+from hanspell import spell_checker
 
 app = Flask(__name__)
 CORS(app)
@@ -324,12 +325,12 @@ def respond():
     user_message = request.json.get('message')
 
     time.sleep(1)
-
+    correct_message = spell_checker.check(user_message)
     # 사용자 메시지에서 불용어 제거 후 키워드 추출
-    keywords = extract_keywords(user_message)
+    keywords = extract_keywords(correct_message.checked)
     
     # 사용자 의도 파악
-    intent = detect_intent(user_message)
+    intent = detect_intent(correct_message.checked)
     
     # 의도에 따른 응답
     if intent == "greeting":

--- a/app.py
+++ b/app.py
@@ -325,6 +325,7 @@ def respond():
     user_message = request.json.get('message')
 
     time.sleep(1)
+    #오타 및 맞춤법 검사
     correct_message = spell_checker.check(user_message)
     # 사용자 메시지에서 불용어 제거 후 키워드 추출
     keywords = extract_keywords(correct_message.checked)


### PR DESCRIPTION
hanspell 모듈을 이용한 오타 및 맞춤법 교정
hanspell 모듈 설치 필요
처음 실행시 KeyError: 'result' 에러 발생
로컬에 설치된 파이썬 파일에서 일부 코드 수정 필요
Python312 > Lib > hanspell > spell_checker.py 파일 찾아서

payload = {
'passportKey': 'd97f073045828282fddba2af384b8866df4c46e5',
'where': 'nexearch',
'color_blindness': 0,
'_': 1732118108451,
'q': text
}

payload를 다음과 같이 수정